### PR TITLE
remove unused variable from optstringfield

### DIFF
--- a/ext/include/_helpers.c
+++ b/ext/include/_helpers.c
@@ -317,7 +317,6 @@ optintfield(lua_State *L, int index, const char *k, int def)
 static const char *
 optstringfield(lua_State *L, int index, const char *k, const char *def)
 {
-	const char *r;
 	int got_type;
 	got_type = lua_type(L, -1);
 	lua_pop(L, 1);


### PR DESCRIPTION
This previoulsy failed to build on FreeBSD using FreeBSD's base system
build infrastructure, due to -Werror and a warning for this unused
variable.