### PR TITLE
add support for Lua 5.4

### DIFF
--- a/ext/include/_helpers.c
+++ b/ext/include/_helpers.c
@@ -53,7 +53,7 @@
 #  endif
 #endif
 
-#if LUA_VERSION_NUM == 502 || LUA_VERSION_NUM == 503
+#if LUA_VERSION_NUM >= 502
 #  define lua_objlen lua_rawlen
 #  define lua_strlen lua_rawlen
 #  define luaL_openlib(L,n,l,nup) luaL_setfuncs((L),(l),(nup))


### PR DESCRIPTION
_helpers.c is a copy from luaposix, and needs one trivial change for
compatibility with Lua 5.4.  luaposix added 5.4 support by appending
a `LUA_VERSION_NUM == 504` case to an existing #ifdef for 502 and 503.

I chose instead to change it to >= 502, to fix for this 5.4 and avoid
encountering this issue again with the next Lua update.